### PR TITLE
Minor fix in downloading scripts

### DIFF
--- a/scripts/download_codeforces.sh
+++ b/scripts/download_codeforces.sh
@@ -68,9 +68,9 @@ then
   rm -rf "$DATA_PATH"_parsed
 fi
 mkdir "$DATA_PATH"_parsed
-java -jar -Xmx200g "$ASTMINER_PATH" code2vec --lang cpp --project "$DATA_PATH"/train --output "$DATA_PATH"_parsed/train --maxH 8 --maxW 2 --granularity file --folder-label --split-tokens
-java -jar -Xmx200g "$ASTMINER_PATH" code2vec --lang cpp --project "$DATA_PATH"/test --output "$DATA_PATH"_parsed/test --maxH 8 --maxW 2 --granularity file --folder-label --split-tokens
-java -jar -Xmx200g "$ASTMINER_PATH" code2vec --lang cpp --project "$DATA_PATH"/val --output "$DATA_PATH"_parsed/val --maxH 8 --maxW 2 --granularity file --folder-label --split-tokens
+java -jar -Xmx200g "$ASTMINER_PATH" code2vec --lang cpp --project "$DATA_PATH"/train --output "$DATA_PATH"_parsed/train --maxL 8 --maxW 2 --granularity file --folder-label --split-tokens
+java -jar -Xmx200g "$ASTMINER_PATH" code2vec --lang cpp --project "$DATA_PATH"/test --output "$DATA_PATH"_parsed/test --maxL 8 --maxW 2 --granularity file --folder-label --split-tokens
+java -jar -Xmx200g "$ASTMINER_PATH" code2vec --lang cpp --project "$DATA_PATH"/val --output "$DATA_PATH"_parsed/val --maxL 8 --maxW 2 --granularity file --folder-label --split-tokens
 for folder in $(find "$DATA_PATH"_parsed/*/cpp -type d)
 do
   for file in "$folder"/*

--- a/scripts/download_data.sh
+++ b/scripts/download_data.sh
@@ -9,7 +9,7 @@ LOAD_SPLITTED=false
 DATA_DIR=./data
 POJ_DOWNLOAD_SCRIPT=./scripts/download_poj.sh
 CODEFORCES_DOWNLOAD_SCRIPT=./scripts/download_codeforces.sh
-ASTMINER_PATH=../astminer/build/shadow/lib-0.5.jar
+ASTMINER_PATH=../astminer/build/shadow/lib-0.*.jar
 SPLIT_SCRIPT=./scripts/split_dataset.sh
 
 function is_int(){
@@ -24,10 +24,10 @@ while (( "$#" )); do
     -h|--help)
       echo "options:"
       echo "-h, --help                     show brief help"
-      echo "-d, --dataset=NAME             specify dataset name, available: java-small, java-med, java-large, poj_104"
-      echo "--train-part=VAL               specify a percentage of dataset used as train set"
-      echo "--test-part=VAL                specify a percentage of dataset used as test set"
-      echo "--val-part=VAL                 specify a percentage of dataset used as validation set"
+      echo "-d, --dataset NAME             specify dataset name, available: java-small, java-med, java-large, poj_104"
+      echo "--train-part VAL               specify a percentage of dataset used as train set"
+      echo "--test-part VAL                specify a percentage of dataset used as test set"
+      echo "--val-part VAL                 specify a percentage of dataset used as validation set"
       echo "--dev                          pass it if developer mode should be used, default false"
       echo "--load-splitted                pass it if splitted dataset needs to be loaded, available only for poj_104, default false"
       exit 0

--- a/scripts/download_poj.sh
+++ b/scripts/download_poj.sh
@@ -80,9 +80,9 @@ then
 fi
 mkdir "$DATA_PATH"_parsed
 
-java -jar -Xmx200g $ASTMINER_PATH code2vec --lang c --project "$DATA_PATH"/train --output "$DATA_PATH"_parsed/train --maxH 8 --maxW 2 --granularity file --folder-label --split-tokens
-java -jar -Xmx200g $ASTMINER_PATH code2vec --lang c --project "$DATA_PATH"/test --output "$DATA_PATH"_parsed/test --maxH 8 --maxW 2 --granularity file --folder-label --split-tokens
-java -jar -Xmx200g $ASTMINER_PATH code2vec --lang c --project "$DATA_PATH"/val --output "$DATA_PATH"_parsed/val --maxH 8 --maxW 2 --granularity file --folder-label --split-tokens
+java -jar -Xmx200g $ASTMINER_PATH code2vec --lang c --project "$DATA_PATH"/train --output "$DATA_PATH"_parsed/train --maxL 8 --maxW 2 --granularity file --folder-label --split-tokens
+java -jar -Xmx200g $ASTMINER_PATH code2vec --lang c --project "$DATA_PATH"/test --output "$DATA_PATH"_parsed/test --maxL 8 --maxW 2 --granularity file --folder-label --split-tokens
+java -jar -Xmx200g $ASTMINER_PATH code2vec --lang c --project "$DATA_PATH"/val --output "$DATA_PATH"_parsed/val --maxL 8 --maxW 2 --granularity file --folder-label --split-tokens
 for folder in $(find "$DATA_PATH"_parsed/*/c -type d)
 do
   for file in "$folder"/*
@@ -92,3 +92,5 @@ do
   done
   rm -rf "$(dirname "$folder")"
 done
+mv "$DATA_PATH" "$DATA_PATH"_pure_files
+mv "$DATA_PATH"_parsed "$DATA_PATH"


### PR DESCRIPTION
Fix following issues that occurred during downloading and processing with `astminer`:
1. Switch version to `build/shadow/lib-0.*.jar` in `download_data.sh`
2. Rename `maxH` arg in `astminer` call to `maxL`
3. Fix description of `download_data.sh`
4. Rename folders with `poj` dataset. Now after processing with `astminer` we have two folders: `poj_104` containing all the data from `astminer` and `poj_104_pure_files` containing pre files