### PR TITLE
Reset metrics after each epoch

### DIFF
--- a/code2seq/model/code2class.py
+++ b/code2seq/model/code2class.py
@@ -84,6 +84,7 @@ class Code2Class(LightningModule):
             mean_loss = torch.stack([out[f"{step}/loss"] for out in outputs]).mean()
             accuracy = self.__metrics[f"{step}_acc"].compute()
             log = {f"{step}/loss": mean_loss, f"{step}/accuracy": accuracy}
+            self.__metrics[f"{step}_acc"].reset()
         self.log_dict(log, on_step=False, on_epoch=True)
 
     def training_epoch_end(self, outputs: EPOCH_OUTPUT):

--- a/code2seq/model/code2seq.py
+++ b/code2seq/model/code2seq.py
@@ -140,6 +140,7 @@ class Code2Seq(LightningModule):
                 f"{step}/precision": metric.precision,
                 f"{step}/recall": metric.recall,
             }
+            self.__metrics[f"{step}_f1"].reset()
         self.log_dict(log, on_step=False, on_epoch=True)
 
     def training_epoch_end(self, step_outputs: EPOCH_OUTPUT):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = "1.0.2"
+VERSION = "1.0.3"
 
 with open("README.md") as readme_file:
     readme = readme_file.read()


### PR DESCRIPTION
Without resetting, metrics accumulate state over multiple epochs. It leads to the underestimation of metrics during training or subsequent testing iterations: while the model improves, metrics accumulate worse values (e.g., less true positives and more false positives).